### PR TITLE
Fix yogo layout on debian

### DIFF
--- a/debian.Dockerfile
+++ b/debian.Dockerfile
@@ -1,0 +1,49 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# Base image is Debian 11.2
+FROM debian:11.2
+
+# Update, install apt utils, curl, & unzip
+RUN apt-get update \
+&& apt-get install apt-utils build-essential curl unzip gcc g++ clang -y
+
+# Install cmake
+RUN apt-get install cmake -y
+
+# Make APL Core with gcc
+ADD . /apl-core
+RUN cd apl-core \
+	&& rm -rf build \
+	&& mkdir build \
+	&& cd build \
+	&& cmake -DBUILD_TESTS=ON -DCOVERAGE=OFF .. \
+	&& make -j4
+
+ # RUN APL Core Tests
+RUN cd apl-core/build \
+	&& unit/unittest
+
+
+# Make APL Core with clang
+ADD . /apl-core
+RUN cd apl-core \
+	&& rm -rf build-clang \
+	&& mkdir build-clang \
+	&& cd build-clang \
+	&& cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DBUILD_TESTS=ON -DCOVERAGE=OFF .. \
+	&& make -j4
+
+ # RUN APL Core Tests
+RUN cd apl-core/build-clang \
+	&& unit/unittest

--- a/patches/yoga.patch
+++ b/patches/yoga.patch
@@ -240,8 +240,8 @@ new file mode 100644
 index 0000000..e69de29
 diff --git a/yoga/event/event.h b/yoga/event/event.h
 index 39b0739..8e5edb1 100644
---- a/thirdparty/yoga-1.16.0/yoga/event/event.h
-+++ b/thirdparty/yoga-1.16.0/yoga/event/event.h
+--- a/yoga/event/event.h
++++ a/yoga/event/event.h
 @@ -10,6 +10,7 @@
  #include <vector>
  #include <array>

--- a/patches/yoga.patch
+++ b/patches/yoga.patch
@@ -18,7 +18,7 @@ index 02e6078..2d53a87 100644
 @@ -172,16 +172,16 @@ inline std::vector<StackTraceElement> getStackTraceSymbols(
    return getStackTraceSymbols(getStackTrace(skip + 1, limit));
  }
- 
+
 -/**
 - * Formatting a stack trace element
 - */
@@ -39,7 +39,7 @@ index 02e6078..2d53a87 100644
 +// */
 +//std::ostream& operator<<(std::ostream& out,
 +//                         const std::vector<StackTraceElement>& trace);
- 
+
  /**
   * Log stack trace
 diff --git a/lib/fb/src/main/cpp/lyra/lyra.cpp b/lib/fb/src/main/cpp/lyra/lyra.cpp
@@ -47,7 +47,7 @@ index 599a360..c4c514c 100644
 --- a/lib/fb/src/main/cpp/lyra/lyra.cpp
 +++ b/lib/fb/src/main/cpp/lyra/lyra.cpp
 @@ -8,7 +8,6 @@
- 
+
  #include <atomic>
  #include <ios>
 -#include <ostream>
@@ -57,7 +57,7 @@ index 599a360..c4c514c 100644
 @@ -116,35 +115,35 @@ void getStackTraceSymbols(vector<StackTraceElement>& symbols,
    }
  }
- 
+
 -ostream& operator<<(ostream& out, const StackTraceElement& elm) {
 -  IosFlagsSaver flags{out};
 -
@@ -116,7 +116,7 @@ index 599a360..c4c514c 100644
 +//
 +//  return out;
 +//}
- 
+
  void logStackTrace(const vector<StackTraceElement>& trace) {
    auto i = 0;
 diff --git a/lib/fb/src/main/cpp/lyra/lyra_exceptions.cpp b/lib/fb/src/main/cpp/lyra/lyra_exceptions.cpp
@@ -124,12 +124,12 @@ index c07e6fd..0fbcb0f 100644
 --- a/lib/fb/src/main/cpp/lyra/lyra_exceptions.cpp
 +++ b/lib/fb/src/main/cpp/lyra/lyra_exceptions.cpp
 @@ -8,7 +8,6 @@
- 
+
  #include <cstdlib>
  #include <exception>
 -#include <sstream>
  #include <typeinfo>
- 
+
  #include <fbjni/detail/Log.h>
 @@ -76,9 +75,7 @@ std::string toString(std::exception_ptr ptr) {
    try {
@@ -151,7 +151,7 @@ index be019d1..c57836b 100644
  #include <gtest/gtest.h>
  #include <yoga/YGNode.h>
 -#include <ostream>
- 
+
  inline bool operator==(const YGSize& lhs, const YGSize& rhs) {
    return lhs.width == rhs.width && lhs.height == rhs.height;
 diff --git a/tests/YGStyleTest.cpp b/tests/YGStyleTest.cpp
@@ -163,7 +163,7 @@ index 530d8de..0ef14e9 100644
  #include <gtest/gtest.h>
  #include <yoga/YGNode.h>
 -#include <iostream>
- 
+
  TEST(YogaTest, copy_style_same) {
    const YGNodeRef node0 = YGNodeNew();
 diff --git a/yoga/YGNode.cpp b/yoga/YGNode.cpp
@@ -177,7 +177,7 @@ index bb240df..85fc976 100644
 -#include <iostream>
  #include "CompactValue.h"
  #include "Utils.h"
- 
+
 diff --git a/yoga/YGNodePrint.cpp b/yoga/YGNodePrint.cpp
 index f91d037..b00c6fe 100644
 --- a/yoga/YGNodePrint.cpp
@@ -203,7 +203,7 @@ index 8df30e2..cafe23f 100644
 +#ifndef NDEBUG
  #pragma once
  #include <string>
- 
+
 diff --git a/yoga/Yoga.cpp b/yoga/Yoga.cpp
 index 1a374ab..6d4a0e4 100644
 --- a/yoga/Yoga.cpp
@@ -211,7 +211,7 @@ index 1a374ab..6d4a0e4 100644
 @@ -945,7 +945,7 @@ bool YGLayoutNodeInternal(
      const uint32_t depth,
      const uint32_t generationCount);
- 
+
 -#ifdef DEBUG
 +#ifndef NDEBUG
  static void YGNodePrintInternal(
@@ -220,7 +220,7 @@ index 1a374ab..6d4a0e4 100644
 @@ -4140,7 +4140,7 @@ void YGNodeCalculateLayoutWithContext(
          node->getLayout().direction(), ownerWidth, ownerHeight, ownerWidth);
      YGRoundToPixelGrid(node, node->getConfig()->pointScaleFactor, 0.0f, 0.0f);
- 
+
 -#ifdef DEBUG
 +#ifndef NDEBUG
      if (node->getConfig()->printTree) {
@@ -229,7 +229,7 @@ index 1a374ab..6d4a0e4 100644
 @@ -4202,7 +4202,7 @@ void YGNodeCalculateLayoutWithContext(
            !nodeWithoutLegacyFlag->isLayoutTreeEqualToNode(*node);
        node->setLayoutDoesLegacyFlagAffectsLayout(neededLegacyStretchBehaviour);
- 
+
 -#ifdef DEBUG
 +#ifndef NDEBUG
        if (nodeWithoutLegacyFlag->getConfig()->printTree) {
@@ -238,3 +238,15 @@ index 1a374ab..6d4a0e4 100644
 diff --git b/yoga/yoga.patch b/yoga/yoga.patch
 new file mode 100644
 index 0000000..e69de29
+diff --git a/yoga/event/event.h b/yoga/event/event.h
+index 39b0739..8e5edb1 100644
+--- a/thirdparty/yoga-1.16.0/yoga/event/event.h
++++ b/thirdparty/yoga-1.16.0/yoga/event/event.h
+@@ -10,6 +10,7 @@
+ #include <vector>
+ #include <array>
+ #include <yoga/YGEnums.h>
++#include <stdint.h>
+
+ struct YGConfig;
+ struct YGNode;


### PR DESCRIPTION
Fix #1 

The issue can be fixed by adding `#include <stdint.h>` to `event.h` of `yoga-layout`. This include is part of the latest version of `yoga-layout` (`1.9.0`).

https://github.com/facebook/yoga/blob/bd95b3d243c45ace339bfb5c12d81e66bac5ec74/yoga/event/event.h#L14

The current project uses `yoga-layout` version `1.6.0`, which is already quite old (Sep 16, 2019). Testing and adopting the latest version of `yoga-layout` would be preferred in the long term. For now I'm patching the issue to minimize the changes made to the project and thus preventing the introduction of new issues.